### PR TITLE
Return fields to fix `woocommerce_email_order_meta_fields` filter

### DIFF
--- a/admin/class-woo-order-weight-admin.php
+++ b/admin/class-woo-order-weight-admin.php
@@ -668,6 +668,8 @@ class Woo_Order_Weight_Admin {
 				return $fields;
 		 endif;
 	 }
+
+	 return $fields;
  }
 
 }


### PR DESCRIPTION
This will solve an issue in another plugin:

- https://github.com/pronamic/woocommerce-checkout-field-editor-pro/issues/1
